### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![ReviewTime](https://github.com/nthegedus/ReviewTime/blob/master/Design/ReviewTime.png)
 # ReviewTime
+
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=56575d7528898101003ae8ae&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/56575d7528898101003ae8ae/build/latest)
+
 Review Time is an open source app for iOS written in Swift that show the average review times for iOS and the Mac Apps using data crowdsourced from AppReviewTime (http://appreviewtimes.com/).
 
 ### Requirements


### PR DESCRIPTION
We really like Review Time and wanted to offer you a free continuous integration system [(buddybuild)](buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/56575d7528898101003ae8ae/build/latest) are the builds we've completed for Review Time so far.

![screen shot 2015-11-26 at 11 39 30 am](https://cloud.githubusercontent.com/assets/13876667/11429861/6b034ec2-9432-11e5-8cce-ee7f7047c92d.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.